### PR TITLE
Extra check when launching Windows services

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ Up until this point we have only deployed a single service application, and that
     ```
 
     > Note: Keep checking the status of the service until the `CURRENT STATE` is running. This usually takes 2-3 minutes
+    
+    > Note: Also, check your service using 'docker service ls', that it displays '1/1' replicas.  If '0/1' replicas is shown the service is not fully available yet, even when 'docker service ps database' shows the service as running.  You should wait until 'docker service ls', shows '1/1' replicas
 
 1. Start the web front-end service
 


### PR DESCRIPTION
When launching Windows services often 'docker service ps <service>' would show the service as running when in fact not all tasks are deployed yet.

Running 'docker service ls' might show for example

ID                  NAME                MODE                REPLICAS            IMAGE                               PORTS
    tqvr2cxk31tr        appserver           replicated          0/1                 mikegcoleman/atsea-appserver:1.0   *:8080->8080/

before reaching the 'desired state' of

ID                  NAME                MODE                REPLICAS            IMAGE                               PORTS
    tqvr2cxk31tr        appserver           replicated          1/1                 mikegcoleman/atsea-appserver:1.0   *:8080->8080/